### PR TITLE
Dasithw/custom ordering using builder

### DIFF
--- a/src/MediatR/BehaviourOrder.cs
+++ b/src/MediatR/BehaviourOrder.cs
@@ -42,6 +42,7 @@ namespace MediatR
             var constructedTypes = _registeredTypes
                 .Select(t =>
                 {
+                    // Try catch is the most reliable approach https://stackoverflow.com/a/4864565/422427
                     try
                     {
                         return t.MakeGenericType(typeof(TRequest), typeof(TResponse));

--- a/src/MediatR/BehaviourOrder.cs
+++ b/src/MediatR/BehaviourOrder.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MediatR
+{
+    public delegate void RegisterFunc(Type serviceType);
+
+    public interface IBehaviorOrder
+    {
+        public void Register(Type type);
+        public IReadOnlyList<IPipelineBehavior<TRequest, TResponse>> GetPipelineBehaviors<TRequest, TResponse>(ServiceFactory serviceFactory) where TRequest : notnull;
+    }
+
+    public class BehaviorOrder : IBehaviorOrder
+    {
+        private readonly RegisterFunc _registerFunc;
+
+        internal BehaviorOrder(RegisterFunc registerFunc) => _registerFunc = registerFunc;
+
+        private readonly List<Type> _registeredTypes = new List<Type>();
+
+        public void Register(Type type)
+        {
+            if (!_registeredTypes.Contains(type))
+            {
+                _registeredTypes.Add(type);
+            }
+
+            _registerFunc(type);
+        }
+
+        public IReadOnlyList<IPipelineBehavior<TRequest, TResponse>> GetPipelineBehaviors<TRequest, TResponse>(ServiceFactory serviceFactory)
+            where TRequest : notnull
+        {
+            var allMatchingTypes =
+                (IEnumerable<IPipelineBehavior<TRequest, TResponse>>) serviceFactory(
+                    typeof(IEnumerable<IPipelineBehavior<TRequest, TResponse>>));
+
+            var constructedTypes = _registeredTypes
+                .Select(t => t.MakeGenericType(typeof(TRequest), typeof(TResponse)))
+                .ToList();
+
+            int OrderFunc(Type t)
+            {
+                var matchedType = constructedTypes.FirstOrDefault(x => x.IsAssignableFrom(t));
+                if (matchedType != null)
+                {
+                    return constructedTypes.IndexOf(matchedType);
+                }
+
+                return -1;
+            }
+
+            return allMatchingTypes
+                .OrderBy(t => (Func<Type, int>) OrderFunc)
+                .ToList();
+        }
+    }
+
+    public static class BehaviorOrderBuilder
+    {
+        public static BehaviorOrder Create(RegisterFunc func) => new BehaviorOrder(func);
+
+        public static BehaviorOrder RegisterBehaviour(this BehaviorOrder behaviorOrder, Type t)
+        {
+            behaviorOrder.Register(t);
+            return behaviorOrder;
+        }
+    }
+}

--- a/src/MediatR/BehaviourOrder.cs
+++ b/src/MediatR/BehaviourOrder.cs
@@ -40,12 +40,23 @@ namespace MediatR
                     typeof(IEnumerable<IPipelineBehavior<TRequest, TResponse>>));
 
             var constructedTypes = _registeredTypes
-                .Select(t => t.MakeGenericType(typeof(TRequest), typeof(TResponse)))
+                .Select(t =>
+                {
+                    try
+                    {
+                        return t.MakeGenericType(typeof(TRequest), typeof(TResponse));
+                    }
+                    catch (Exception)
+                    {
+                        return null;
+                    }
+                })
+                .Where(t => t != null)
                 .ToList();
 
             int OrderFunc(Type t)
             {
-                var matchedType = constructedTypes.FirstOrDefault(x => x.IsAssignableFrom(t));
+                var matchedType = constructedTypes.FirstOrDefault(x => x!.IsAssignableFrom(t));
                 if (matchedType != null)
                 {
                     return constructedTypes.IndexOf(matchedType);
@@ -55,7 +66,7 @@ namespace MediatR
             }
 
             return allMatchingTypes
-                .OrderBy(t => (Func<Type, int>) OrderFunc)
+                .OrderBy(t => OrderFunc(t.GetType()))
                 .ToList();
         }
     }

--- a/src/MediatR/ServiceFactory.cs
+++ b/src/MediatR/ServiceFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MediatR
 {

--- a/src/MediatR/ServiceFactory.cs
+++ b/src/MediatR/ServiceFactory.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace MediatR
 {

--- a/src/MediatR/Wrappers/RequestHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/RequestHandlerWrapper.cs
@@ -51,8 +51,10 @@ namespace MediatR.Wrappers
         {
             Task<TResponse> Handler() => GetHandler<IRequestHandler<TRequest, TResponse>>(serviceFactory).Handle((TRequest) request, cancellationToken);
 
-            return serviceFactory
-                .GetInstances<IPipelineBehavior<TRequest, TResponse>>()
+            var pipelineOrder = (IBehaviorOrder) serviceFactory(typeof(IBehaviorOrder));
+            
+            return pipelineOrder
+                .GetPipelineBehaviors<TRequest, TResponse>(serviceFactory)
                 .Reverse()
                 .OrderBy(i => i.GetType()
                                   .GetCustomAttributes(typeof(PipelinePriorityAttribute), true)

--- a/src/MediatR/Wrappers/RequestHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/RequestHandlerWrapper.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace MediatR.Wrappers
 {
     using System;
@@ -44,17 +46,25 @@ namespace MediatR.Wrappers
     {
         public override async Task<object?> Handle(object request, CancellationToken cancellationToken,
             ServiceFactory serviceFactory) =>
-            await Handle((IRequest<TResponse>)request, cancellationToken, serviceFactory);
+            await Handle((IRequest<TResponse>) request, cancellationToken, serviceFactory);
 
         public override Task<TResponse> Handle(IRequest<TResponse> request, CancellationToken cancellationToken,
             ServiceFactory serviceFactory)
         {
             Task<TResponse> Handler() => GetHandler<IRequestHandler<TRequest, TResponse>>(serviceFactory).Handle((TRequest) request, cancellationToken);
 
-            var pipelineOrder = (IBehaviorOrder) serviceFactory(typeof(IBehaviorOrder));
-            
-            return pipelineOrder
-                .GetPipelineBehaviors<TRequest, TResponse>(serviceFactory)
+            IEnumerable<IPipelineBehavior<TRequest, TResponse>> pipelineBehaviors;
+
+            try
+            {
+                pipelineBehaviors = ((IBehaviorOrder) serviceFactory(typeof(IBehaviorOrder))).GetPipelineBehaviors<TRequest, TResponse>(serviceFactory);
+            }
+            catch (Exception)
+            {
+                pipelineBehaviors = (IEnumerable<IPipelineBehavior<TRequest, TResponse>>) serviceFactory(typeof(IEnumerable<IPipelineBehavior<TRequest, TResponse>>));
+            }
+
+            return pipelineBehaviors
                 .Reverse()
                 .OrderBy(i => i.GetType()
                                   .GetCustomAttributes(typeof(PipelinePriorityAttribute), true)

--- a/src/MediatR/Wrappers/RequestHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/RequestHandlerWrapper.cs
@@ -66,10 +66,6 @@ namespace MediatR.Wrappers
 
             return pipelineBehaviors
                 .Reverse()
-                .OrderBy(i => i.GetType()
-                                  .GetCustomAttributes(typeof(PipelinePriorityAttribute), true)
-                                  .Cast<PipelinePriorityAttribute>()
-                                  .FirstOrDefault()?.Priority ?? PipelinePriorityOrder.Normal)
                 .Aggregate((RequestHandlerDelegate<TResponse>) Handler, (next, pipeline) => () => pipeline.Handle((TRequest) request, cancellationToken, next))();
         }
     }

--- a/src/MediatR/Wrappers/RequestHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/RequestHandlerWrapper.cs
@@ -57,9 +57,10 @@ namespace MediatR.Wrappers
 
             try
             {
-                pipelineBehaviors = ((IBehaviorOrder) serviceFactory(typeof(IBehaviorOrder))).GetPipelineBehaviors<TRequest, TResponse>(serviceFactory);
+                var instance = (IBehaviorOrder) serviceFactory(typeof(IBehaviorOrder));
+                pipelineBehaviors = instance.GetPipelineBehaviors<TRequest, TResponse>(serviceFactory);
             }
-            catch (Exception)
+            catch (Exception) // when an IBehaviour instance can't be found in container
             {
                 pipelineBehaviors = (IEnumerable<IPipelineBehavior<TRequest, TResponse>>) serviceFactory(typeof(IEnumerable<IPipelineBehavior<TRequest, TResponse>>));
             }

--- a/test/MediatR.Tests/PipelineTests.cs
+++ b/test/MediatR.Tests/PipelineTests.cs
@@ -437,50 +437,5 @@ namespace MediatR.Tests
                 "Outer generic after",
             });
         }
-
-        [Fact]
-        public async Task Should_wrap_with_behavior_with_priority()
-        {
-            var output = new Logger();
-            var container = new Container(cfg =>
-            {
-                cfg.Scan(scanner =>
-                {
-                    scanner.AssemblyContainingType(typeof(PublishTests));
-                    scanner.IncludeNamespaceContainingType<Ping>();
-                    scanner.WithDefaultConventions();
-                    scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
-                });
-                cfg.For<Logger>().Singleton().Use(output);
-                cfg.For<IPipelineBehavior<Ping, Pong>>().Add<OuterBehavior>();
-                cfg.For<IPipelineBehavior<Ping, Pong>>().Add<NormalPriorityBehavior>();
-                cfg.For<IPipelineBehavior<Ping, Pong>>().Add<HighPriorityBehavior>();
-                cfg.For<IPipelineBehavior<Ping, Pong>>().Add<LowPriorityBehavior>();
-                cfg.For<IPipelineBehavior<Ping, Pong>>().Add<InnerBehavior>();
-                cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
-                cfg.For<IMediator>().Use<Mediator>();
-            });
-
-            var mediator = container.GetInstance<IMediator>();
-
-            var response = await mediator.Send(new Ping { Message = "Ping" });
-
-            response.Message.ShouldBe("Ping Pong");
-
-            output.Messages.ShouldBe(new[]
-            {
-                "High Priority before",
-                "Outer before",
-                "Normal Priority before",
-                "Inner before",
-                "Low Priority before",
-                "Handler",
-                "Low Priority after",
-                "Inner after",
-                "Normal Priority after",
-                "Outer after",
-                "High Priority after"
-            });
-        }
     }
 }

--- a/test/MediatR.Tests/PipelineTests.cs
+++ b/test/MediatR.Tests/PipelineTests.cs
@@ -333,12 +333,16 @@ namespace MediatR.Tests
                 });
                 cfg.For<Logger>().Singleton().Use(output);
 
-                cfg.For(typeof(IPipelineBehavior<,>)).Add(typeof(OuterBehavior<,>));
-                cfg.For(typeof(IPipelineBehavior<,>)).Add(typeof(InnerBehavior<,>));
-                cfg.For(typeof(IPipelineBehavior<,>)).Add(typeof(ConstrainedBehavior<,>));
-
                 cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
                 cfg.For<IMediator>().Use<Mediator>();
+
+                var x = BehaviorOrderBuilder
+                    .Create(t => cfg.For(typeof(IPipelineBehavior<,>)).Add(t))
+                    .RegisterBehaviour(typeof(OuterBehavior<,>))
+                    .RegisterBehaviour(typeof(InnerBehavior<,>))
+                    .RegisterBehaviour(typeof(ConstrainedBehavior<,>));
+                
+                cfg.For<IBehaviorOrder>().Add(x);
             });
 
             container.GetAllInstances<IPipelineBehavior<Ping, Pong>>();


### PR DESCRIPTION
This is a draft which gets rid of the `PipelinePrirityAttribute` and replaces it with a mechanism to register pipeline behaviour order explicitly. See discussion in https://github.com/jbogard/MediatR/pull/509 and comment from @jbogard https://github.com/jbogard/MediatR/pull/509#issuecomment-870583628